### PR TITLE
Fix error message description

### DIFF
--- a/fluent-plugin-openlineage.gemspec
+++ b/fluent-plugin-openlineage.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-openlineage"
-  spec.version = "0.1.0"
+  spec.version = "0.1.2"
   spec.authors = ["Pawel Leszczynski"]
   spec.email   = ["leszczynski.pawel@gmail.com"]
 

--- a/lib/fluent/plugin/parser_openlineage.rb
+++ b/lib/fluent/plugin/parser_openlineage.rb
@@ -63,7 +63,7 @@ module Fluent
       def enrich_oneOf_errors(json)
         errors = []
         @schema["oneOf"].each { |ref|
-          changed_schema = @schema
+          changed_schema = Marshal.load(Marshal.dump(@schema))
           changed_schema.delete("oneOf")
           changed_schema["$ref"] = ref["$ref"]
           validator = RustyJSONSchema.build(changed_schema)


### PR DESCRIPTION
after the first msg error, all other error msg would be of a generic type. This fix corrects this behavior.